### PR TITLE
Fix expiring products due-soon handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,14 +22,14 @@ repos:
     hooks:
       - id: validate-hacs
         name: Validate HACS configuration
-        entry: python3 -c "import json; json.load(open('hacs.json'))"
+        entry: python -c "import json; json.load(open('hacs.json'))"
         language: system
         files: ^hacs\.json$
         pass_filenames: false
 
       - id: validate-manifest
         name: Validate Home Assistant manifest
-        entry: python3 -c "import json; json.load(open('custom_components/grocy/manifest.json'))"
+        entry: python -c "import json; json.load(open('custom_components/grocy/manifest.json'))"
         language: system
         files: ^custom_components/.*/manifest\.json$
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,14 +22,14 @@ repos:
     hooks:
       - id: validate-hacs
         name: Validate HACS configuration
-        entry: python -c "import json; json.load(open('hacs.json'))"
+        entry: python3 -c "import json; json.load(open('hacs.json'))"
         language: system
         files: ^hacs\.json$
         pass_filenames: false
 
       - id: validate-manifest
         name: Validate Home Assistant manifest
-        entry: python -c "import json; json.load(open('custom_components/grocy/manifest.json'))"
+        entry: python3 -c "import json; json.load(open('custom_components/grocy/manifest.json'))"
         language: system
         files: ^custom_components/.*/manifest\.json$
         pass_filenames: false

--- a/custom_components/grocy/grocy_data.py
+++ b/custom_components/grocy/grocy_data.py
@@ -100,9 +100,36 @@ class GrocyData:
         def wrapper():
             config = self.api.system.config()
             try:
-                val = self.api.users.get_setting("STOCK_DUE_SOON_DAYS")
-                if val is not None and isinstance(val, (int, str)):
-                    self.due_soon_days = int(val)
+                # Some Grocy setups expose this key in lowercase only.
+                for key in ("STOCK_DUE_SOON_DAYS", "stock_due_soon_days"):
+                    raw_val = self.api.users.get_setting(key)
+                    _LOGGER.debug("Read user setting %s from Grocy: %r", key, raw_val)
+
+                    val = raw_val
+                    if isinstance(raw_val, dict):
+                        # Handle alternative payload shapes returned by library/API.
+                        for field in ("value", "setting_value"):
+                            if field in raw_val:
+                                val = raw_val[field]
+                                break
+
+                    if val is None:
+                        continue
+
+                    try:
+                        self.due_soon_days = int(val)
+                        _LOGGER.debug(
+                            "Using due_soon_days=%s from key %s",
+                            self.due_soon_days,
+                            key,
+                        )
+                        break
+                    except (TypeError, ValueError):
+                        _LOGGER.debug(
+                            "Ignoring invalid due soon setting value for key %s: %r",
+                            key,
+                            val,
+                        )
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.debug("Could not read STOCK_DUE_SOON_DAYS from Grocy")
             return config
@@ -145,12 +172,21 @@ class GrocyData:
                 # Without this, the API defaults to 5 days regardless of the
                 # STOCK_DUE_SOON_DAYS system setting.
                 api_client = self.api._api_client
+                _LOGGER.debug(
+                    "Fetching expiring products from stock/volatile with due_soon_days=%s",
+                    self.due_soon_days,
+                )
                 raw = api_client._do_get_request(
-                    f"stock/volatile?due_days={self.due_soon_days}"
+                    f"stock/volatile?due_soon_days={self.due_soon_days}"
                 )
                 if not raw:
+                    _LOGGER.debug("stock/volatile returned empty payload")
                     return []
                 volatile = CurrentVolatileStockResponse(**raw)
+                _LOGGER.debug(
+                    "stock/volatile due_products count=%s",
+                    len(volatile.due_products or []),
+                )
                 products = [
                     Product.from_stock_response(r)
                     for r in (volatile.due_products or [])

--- a/docs/test-feature-map.yaml
+++ b/docs/test-feature-map.yaml
@@ -54,6 +54,8 @@ features:
           - test_async_update_overdue_products
           - test_async_update_missing_products
           - test_async_get_config_stores_due_soon_days
+          - test_async_get_config_stores_due_soon_days_lowercase_fallback
+          - test_async_get_config_stores_due_soon_days_from_dict_payload
           - test_async_get_config_due_soon_days_defaults_to_none
           - test_async_get_config_due_soon_days_handles_invalid_value
 

--- a/docs/test-feature-map.yaml
+++ b/docs/test-feature-map.yaml
@@ -290,6 +290,8 @@ features:
           - test_async_update_data_skips_disabled_entities
           - test_async_update_data_raises_update_failed_when_all_fail
           - test_async_update_data_partial_failure_does_not_raise
+          - test_async_update_data_raises_update_failed_when_all_fail_with_previous_data
+          - test_async_update_data_partial_failure_keeps_previous_data
 
 # Cross-cutting tests that validate shared infrastructure.
 # These don't belong to a single feature but are essential.

--- a/tests/test_grocy_data.py
+++ b/tests/test_grocy_data.py
@@ -197,7 +197,7 @@ async def test_async_update_expiring_products(grocy_data) -> None:
 @pytest.mark.feature("stock_management")
 @pytest.mark.asyncio
 async def test_async_update_expiring_products_uses_due_soon_days(grocy_data) -> None:
-    """Verify due_soon_days is passed as due_days to the API when configured."""
+    """Verify due_soon_days is passed to the API when configured."""
     grocy_data.due_soon_days = 7
     grocy_data.api._api_client._do_get_request.return_value = {"due_products": []}
 
@@ -205,7 +205,7 @@ async def test_async_update_expiring_products_uses_due_soon_days(grocy_data) -> 
 
     assert result == []
     grocy_data.api._api_client._do_get_request.assert_called_once_with(
-        "stock/volatile?due_days=7"
+        "stock/volatile?due_soon_days=7"
     )
     grocy_data.api.stock.due_products.assert_not_called()
 
@@ -366,10 +366,41 @@ async def test_async_get_config_stores_due_soon_days(grocy_data) -> None:
 
 @pytest.mark.feature("stock_management")
 @pytest.mark.asyncio
+async def test_async_get_config_stores_due_soon_days_lowercase_fallback(
+    grocy_data,
+) -> None:
+    """Verify lowercase stock_due_soon_days is used when uppercase is absent."""
+    grocy_data.api.system.config.return_value = MagicMock()
+    grocy_data.api.users.get_setting.side_effect = [None, "7"]
+
+    await grocy_data.async_get_config()
+
+    assert grocy_data.due_soon_days == 7
+    assert grocy_data.api.users.get_setting.call_count == 2
+    grocy_data.api.users.get_setting.assert_any_call("STOCK_DUE_SOON_DAYS")
+    grocy_data.api.users.get_setting.assert_any_call("stock_due_soon_days")
+
+
+@pytest.mark.feature("stock_management")
+@pytest.mark.asyncio
+async def test_async_get_config_stores_due_soon_days_from_dict_payload(
+    grocy_data,
+) -> None:
+    """Verify dict payloads from API/client are parsed correctly."""
+    grocy_data.api.system.config.return_value = MagicMock()
+    grocy_data.api.users.get_setting.side_effect = [None, {"value": "7"}]
+
+    await grocy_data.async_get_config()
+
+    assert grocy_data.due_soon_days == 7
+
+
+@pytest.mark.feature("stock_management")
+@pytest.mark.asyncio
 async def test_async_get_config_due_soon_days_defaults_to_none(grocy_data) -> None:
     """Verify due_soon_days is None when STOCK_DUE_SOON_DAYS is absent."""
     grocy_data.api.system.config.return_value = MagicMock()
-    grocy_data.api.users.get_setting.return_value = None
+    grocy_data.api.users.get_setting.side_effect = [None, None]
 
     await grocy_data.async_get_config()
 

--- a/tests/test_grocy_data.py
+++ b/tests/test_grocy_data.py
@@ -205,7 +205,7 @@ async def test_async_update_expiring_products_uses_due_soon_days(grocy_data) -> 
 
     assert result == []
     grocy_data.api._api_client._do_get_request.assert_called_once_with(
-        "stock/volatile?due_soon_days=7"
+        f"stock/volatile?due_soon_days={grocy_data.due_soon_days}"
     )
     grocy_data.api.stock.due_products.assert_not_called()
 


### PR DESCRIPTION
## Summary

This PR fixes expiring-products handling when Grocy is configured with a custom "due soon" window (e.g. 7 days).

Two independent issues were causing incorrect behavior:

1. User setting lookup was case-sensitive  
   - Integration only read `STOCK_DUE_SOON_DAYS`
   - Some Grocy setups return lowercase `stock_due_soon_days`

2. Wrong query parameter for volatile stock endpoint  
   - Integration used `due_days`
   - Correct parameter is `due_soon_days` for `/api/stock/volatile`

---

## Problem

`binary_sensor.grocy_expiring_products` effectively behaved like a fixed 5-day window, even when Grocy user setting was 7 days.

Example from affected setup:

- `GET /api/user/settings/STOCK_DUE_SOON_DAYS` -> `{"value": null}`
- `GET /api/user/settings/stock_due_soon_days` -> `{"value":"7"}`

And with the wrong query param:
- `GET /api/stock/volatile?due_days=7` returned empty due products

---

## Changes

- In `GrocyData.async_get_config()`:
  - Read both setting keys:
    - `STOCK_DUE_SOON_DAYS`
    - `stock_due_soon_days`
  - Parse alternative payload shapes (e.g. dict with `value` / `setting_value`)
  - Keep robust handling for invalid values

- In expiring-products update path:
  - Use:
    - `stock/volatile?due_soon_days=<value>`
  - Instead of:
    - `stock/volatile?due_days=<value>`

- Added/updated tests in `tests/test_grocy_data.py`:
  - lowercase fallback key
  - dict payload parsing
  - correct query parameter assertion (`due_soon_days`)

---

## Validation

Manual validation against Grocy `4.4.1`:

- Integration logs show:
  - uppercase key returns `{'value': None}`
  - lowercase key returns `{'value': '7'}`
  - `due_soon_days=7` is selected

- API call with correct query parameter:
  - `/api/stock/volatile?due_soon_days=7` returns expected due products

- Home Assistant:
  - `binary_sensor.grocy_expiring_products` reflects configured 7-day window correctly

---

## Backward compatibility

- Existing setups using uppercase setting key remain supported.
- Lowercase-key setups now work correctly.
