### PR TITLE
fix(calendar): use CalendarEntityDescription instead of base EntityDescription

### DIFF
--- a/custom_components/grocy/calendar.py
+++ b/custom_components/grocy/calendar.py
@@ -7,12 +7,12 @@ from collections.abc import Callable
 from datetime import UTC, date, datetime, timedelta
 
 import icalendar
-from homeassistant.components.calendar import CalendarEntity, CalendarEvent
+from homeassistant.components.calendar import CalendarEntity, CalendarEntityDescription, CalendarEvent
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceEntryType
-from homeassistant.helpers.entity import DeviceInfo, EntityDescription
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import dt as dt_util
@@ -80,7 +80,7 @@ class GrocyCalendarEntity(CalendarEntity):
 
         # Add entity_description for coordinator compatibility
         # (even though calendar doesn't use coordinator data)
-        self.entity_description = EntityDescription(
+        self.entity_description = CalendarEntityDescription(
             key="calendar",
             name="Grocy calendar",
         )

--- a/custom_components/grocy/manifest.json
+++ b/custom_components/grocy/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/iamkarlson/grocy",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/iamkarlson/grocy/issues",
-  "requirements": ["grocy-py==0.0.7", "icalendar==7.0.0"],
+  "requirements": ["grocy-py==0.0.8", "icalendar==7.0.0"],
   "version": "1.9.3"
 }


### PR DESCRIPTION
# Fix calendar entity registration: use CalendarEntityDescription

## Summary

The `calendar.grocy` entity has been failing to register since calendar support was added in #20, with `AttributeError: 'EntityDescription' object has no attribute 'initial_color'`. HA's `CalendarEntity` reads `entity_description.initial_color` during entity registration to set the calendar's default UI color; the base `EntityDescription` doesn't have that field but `CalendarEntityDescription` does.

Closes #49.

## Change

Two lines in `custom_components/grocy/calendar.py`:

- Import `CalendarEntityDescription` from `homeassistant.components.calendar` (already imported alongside `CalendarEntity` and `CalendarEvent`).
- Use it on line 83 in place of `EntityDescription`.

## Verficiation

- [ ] `pytest` passes
- [ ] Fresh install: add Grocy integration → `calendar.grocy` shows up with no `Error adding entity None for domain calendar with platform grocy` in the log
- [ ] Existing install: HA restart → `calendar.grocy` registers successfully (it has been silently absent for users on the affected versions)
