### PR TITLE
Add best_before_date support to grocy.add_product_to_stock

### DIFF
--- a/custom_components/grocy/services.py
+++ b/custom_components/grocy/services.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import config_validation as cv
 from homeassistant.util import dt as dt_util
 
 from grocy.data_models.generic import EntityType
@@ -16,6 +17,7 @@ from .coordinator import GrocyDataUpdateCoordinator
 SERVICE_PRODUCT_ID = "product_id"
 SERVICE_AMOUNT = "amount"
 SERVICE_PRICE = "price"
+SERVICE_BEST_BEFORE_DATE = "best_before_date"
 SERVICE_SHOPPING_LIST_ID = "shopping_list_id"
 SERVICE_SPOILED = "spoiled"
 SERVICE_SUBPRODUCT_SUBSTITUTION = "allow_subproduct_substitution"
@@ -52,6 +54,7 @@ SERVICE_ADD_PRODUCT_SCHEMA = vol.All(
             vol.Required(SERVICE_PRODUCT_ID): vol.Coerce(int),
             vol.Required(SERVICE_AMOUNT): vol.Coerce(float),
             vol.Optional(SERVICE_PRICE): str,
+            vol.Optional(SERVICE_BEST_BEFORE_DATE): cv.date,
         }
     )
 )
@@ -262,9 +265,12 @@ async def async_add_product_service(
     amount = data[SERVICE_AMOUNT]
     price_raw = data.get(SERVICE_PRICE)
     price = float(price_raw) if price_raw not in (None, "") else 0.0
+    best_before_date = data.get(SERVICE_BEST_BEFORE_DATE)
 
     def wrapper():
-        coordinator.grocy_api.stock.add(product_id, amount, price)
+        coordinator.grocy_api.stock.add(
+            product_id, amount, price, best_before_date=best_before_date
+        )
 
     await hass.async_add_executor_job(wrapper)
 

--- a/custom_components/grocy/services.yaml
+++ b/custom_components/grocy/services.yaml
@@ -26,6 +26,13 @@ add_product_to_stock:
       description: The purchase price per purchase quantity unit of the added product
       selector:
         text:
+    best_before_date:
+      name: Best Before Date
+      example: '2019-01-19'
+      description: The best before date of the added product (YYYY-MM-DD). Defaults to
+        the product's configured default best before days when omitted
+      selector:
+        date:
 
 open_product:
   name: Open Product

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -65,6 +65,7 @@ Add a quantity of a product to stock.
 | `product_id` | int | Yes | Grocy product ID |
 | `amount` | float | Yes | Quantity to add |
 | `price` | string | No | Price per unit (empty or omitted defaults to 0.0) |
+| `best_before_date` | string | No | Best before date as `YYYY-MM-DD`. Omitted means Grocy applies the product's default best before days |
 
 #### `grocy.consume_product_from_stock`
 

--- a/docs/test-feature-map.yaml
+++ b/docs/test-feature-map.yaml
@@ -29,6 +29,10 @@ features:
           - test_add_product_service_converts_price
           - test_add_product_service_defaults_price_zero
           - test_add_product_service_no_price_key
+          - test_add_product_service_passes_best_before_date
+          - test_add_product_service_no_best_before_date
+          - test_add_product_schema_coerces_best_before_date
+          - test_add_product_schema_rejects_bad_best_before_date
           - test_open_product_service_uses_defaults
           - test_open_product_with_substitution
           - test_consume_product_service_handles_transaction_type

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -7,10 +7,12 @@ See: docs/FEATURES.md
 
 from __future__ import annotations
 
+import datetime as dt
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import voluptuous as vol
 from grocy.data_models.generic import EntityType
 from grocy.grocy_api_client import TransactionType
 
@@ -43,7 +45,9 @@ async def test_add_product_service_converts_price(hass, coordinator) -> None:
 
     await services.async_add_product_service(hass, coordinator, data)
 
-    coordinator.grocy_api.stock.add.assert_called_once_with(5, 2.0, 1.25)
+    coordinator.grocy_api.stock.add.assert_called_once_with(
+        5, 2.0, 1.25, best_before_date=None
+    )
 
 
 @pytest.mark.feature("stock_management")
@@ -58,7 +62,9 @@ async def test_add_product_service_defaults_price_zero(hass, coordinator) -> Non
 
     await services.async_add_product_service(hass, coordinator, data)
 
-    coordinator.grocy_api.stock.add.assert_called_once_with(8, 1.0, 0.0)
+    coordinator.grocy_api.stock.add.assert_called_once_with(
+        8, 1.0, 0.0, best_before_date=None
+    )
 
 
 @pytest.mark.feature("stock_management")
@@ -468,7 +474,74 @@ async def test_add_product_service_no_price_key(hass, coordinator) -> None:
 
     await services.async_add_product_service(hass, coordinator, data)
 
-    coordinator.grocy_api.stock.add.assert_called_once_with(10, 5.0, 0.0)
+    coordinator.grocy_api.stock.add.assert_called_once_with(
+        10, 5.0, 0.0, best_before_date=None
+    )
+
+
+# ─── add_product best before date ────────────────────────────────────────────
+
+
+@pytest.mark.feature("stock_management")
+@pytest.mark.asyncio
+async def test_add_product_service_passes_best_before_date(hass, coordinator) -> None:
+    """Verify the best before date is forwarded to Grocy."""
+    data = {
+        services.SERVICE_PRODUCT_ID: 5,
+        services.SERVICE_AMOUNT: 1.0,
+        services.SERVICE_PRICE: "1.99",
+        services.SERVICE_BEST_BEFORE_DATE: dt.date(2019, 1, 19),
+    }
+
+    await services.async_add_product_service(hass, coordinator, data)
+
+    coordinator.grocy_api.stock.add.assert_called_once_with(
+        5, 1.0, 1.99, best_before_date=dt.date(2019, 1, 19)
+    )
+
+
+@pytest.mark.feature("stock_management")
+def test_add_product_schema_coerces_best_before_date() -> None:
+    """Verify the schema turns a date string into the date grocy-py expects."""
+    validated = services.SERVICE_ADD_PRODUCT_SCHEMA(
+        {
+            services.SERVICE_PRODUCT_ID: "3",
+            services.SERVICE_AMOUNT: "1",
+            services.SERVICE_BEST_BEFORE_DATE: "2019-01-19",
+        }
+    )
+
+    assert validated[services.SERVICE_BEST_BEFORE_DATE] == dt.date(2019, 1, 19)
+
+
+@pytest.mark.feature("stock_management")
+@pytest.mark.parametrize("value", ["", "19-01-2019", "not-a-date"])
+def test_add_product_schema_rejects_bad_best_before_date(value) -> None:
+    """Verify an unparseable best before date is rejected, not silently dropped."""
+    with pytest.raises(vol.Invalid):
+        services.SERVICE_ADD_PRODUCT_SCHEMA(
+            {
+                services.SERVICE_PRODUCT_ID: "3",
+                services.SERVICE_AMOUNT: "1",
+                services.SERVICE_BEST_BEFORE_DATE: value,
+            }
+        )
+
+
+@pytest.mark.feature("stock_management")
+@pytest.mark.asyncio
+async def test_add_product_service_no_best_before_date(hass, coordinator) -> None:
+    """Verify an omitted best before date is sent as None."""
+    data = {
+        services.SERVICE_PRODUCT_ID: 7,
+        services.SERVICE_AMOUNT: 1.0,
+    }
+
+    await services.async_add_product_service(hass, coordinator, data)
+
+    coordinator.grocy_api.stock.add.assert_called_once_with(
+        7, 1.0, 0.0, best_before_date=None
+    )
 
 
 # ─── execute_chore with empty done_by ────────────────────────────────────────


### PR DESCRIPTION
## Summary

  Grocy's `POST /stock/products/{id}/add` endpoint (and grocy-py's
  `stock.add()`) already accepts a `best_before_date`, but the
  `grocy.add_product_to_stock` service didn't expose it, so it was
  impossible to set an expiry date when adding stock from Home Assistant.

  This adds an optional `best_before_date` field to the service.

  ## Behavior changes

  - `grocy.add_product_to_stock` accepts a new optional `best_before_date`
    field (date, e.g. `2019-01-19`).
  - Validated with `cv.date` in the service schema, so a string is parsed,
    a `date` object passes through untouched, and anything unparseable is
    rejected with a clear error at the service-call boundary instead of
    being silently dropped.
  - When omitted, behavior is unchanged: Grocy applies the product's
    configured default best-before days, same as before this change.

  ## Testing performed

  - `task test` — full suite passes (224 tests).
  - `task check:features` — new tests registered in
    `docs/test-feature-map.yaml`.
  - Added schema-level tests (string parsed to `date`, invalid formats
    rejected) and handler-level tests (date forwarded to
    `grocy_api.stock.add`, omitted field forwarded as `None`).
  - Manually verified against a real Grocy instance: added stock via
    Developer Tools → Actions with `best_before_date` set, confirmed the
    product's best-before date in the Grocy UI matched; confirmed omitting
    the field still falls back to the product default; confirmed an
    invalid date string (e.g. `19-01-2019`) is rejected rather than
    silently adding stock with no expiry.

  ## Docs

  - `custom_components/grocy/services.yaml` — new field with a `date:`
    selector so it renders as a date picker in the HA service UI.
  - `docs/FEATURES.md` — documented the new parameter.
  - `docs/test-feature-map.yaml` — registered new tests under
    `stock_management`.

  No manifest or dependency changes; no new user-facing entities or
  translations required (the field is HA-native, not per-language text).

Closes #59