### PR TITLE
Fix SyntaxError in async_get_config (except TypeError, ValueError)

### DIFF
--- a/custom_components/grocy/grocy_data.py
+++ b/custom_components/grocy/grocy_data.py
@@ -126,7 +126,7 @@ class GrocyData:
                             key,
                         )
                         break
-                    except TypeError, ValueError:
+                    except (TypeError, ValueError):
                         _LOGGER.debug(
                             "Ignoring invalid due soon setting value for key %s: %r",
                             key,


### PR DESCRIPTION
## Summary

`custom_components/grocy/grocy_data.py` line 129 uses Python 2 exception syntax:

```python
except TypeError, ValueError:
```

This is invalid in Python 3 and raises a `SyntaxError` when the module is compiled/imported:

```
  File ".../grocy_data.py", line 129
    except TypeError, ValueError:
           ^^^^^^^^^^^^^^^^^^^^^
SyntaxError: multiple exception types must be parenthesized
```

Because this is a module-level compile error, it breaks the import of `grocy_data.py` entirely, which breaks setup of the whole Grocy integration as soon as Home Assistant (re)loads it - not just the `STOCK_DUE_SOON_DAYS` code path this `except` belongs to.

This looks like it was introduced together with the `STOCK_DUE_SOON_DAYS` / `stock_due_soon_days` lowercase-fallback handling in `async_get_config` (related to #44 / #45).

## Fix

Parenthesize the exception tuple, as required by Python 3:

```python
except (TypeError, ValueError):
```

## Testing

- `python3 -c "import ast; ast.parse(open('custom_components/grocy/grocy_data.py').read())"` now succeeds (previously raised the `SyntaxError` above).
- One-line change, no behavior change beyond fixing the crash.
