### PR TITLE
fix: handle missing USER_USERNAME in SystemConfigDto for Grocy >= 4.7.0 (#363)

### DIFF
--- a/custom_components/grocy/__init__.py
+++ b/custom_components/grocy/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 
 from aiohttp import ClientConnectorError
+from grocy.grocy_api_client import SystemConfigDto
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -41,6 +42,20 @@ from .services import async_setup_services, async_unload_services
 __all__ = ["async_migrate_entry"]
 
 _LOGGER = logging.getLogger(__name__)
+
+# --- HOTFIX: Compatibilidad Grocy >= 4.7.0 (USER_USERNAME ausente) ---
+if not getattr(SystemConfigDto, "_patched_grocy_470", False):
+    _orig_system_config_init = SystemConfigDto.__init__
+
+    def _patched_system_config_init(self, *args, **kwargs):
+        if "USER_USERNAME" not in kwargs or kwargs["USER_USERNAME"] is None:
+            kwargs["USER_USERNAME"] = "api"
+        _orig_system_config_init(self, *args, **kwargs)
+
+    SystemConfigDto.__init__ = _patched_system_config_init
+    SystemConfigDto._patched_grocy_470 = True
+    _LOGGER.info("Grocy hotfix: interceptor de SystemConfigDto aplicado correctamente.")
+# ----------------------------------------------------------------------
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):


### PR DESCRIPTION


Fixes #60 .

With the release of Grocy 4.7.0, API-key-only authenticated calls to `/api/system/config` no longer return the `USER_USERNAME` attribute in the JSON payload. Because `grocy-py==1.0.0` defines `USER_USERNAME` as a required field on `SystemConfigDto`, Pydantic throws a `ValidationError` during `async_setup_entry` when `_async_get_available_entities` calls `async_get_config()`, completely preventing the integration from initializing.

This PR adds an idempotent runtime compatibility shim in `__init__.py` to provide a fallback value for `USER_USERNAME` when missing from the API response until an updated version of `grocy-py` with an `Optional` field definition is released and vendored.

---

### Changes Made

- **Import `SystemConfigDto`:** Imported from `grocy.grocy_api_client` in `custom_components/grocy/__init__.py`.
- **Runtime Interceptor on `SystemConfigDto.__init__`:** Wraps `__init__` before validation to inject `USER_USERNAME="api"` if the key is missing or `None` in `kwargs`.
- **Idempotency Guard:** Sets a sentinel attribute `_patched_grocy_470` on the class object to prevent recursion or repeated wrapping during integration reloads.
- **Logging:** Emits an informational log entry once applied.

---

### Root Cause & Traceback

```text
pydantic_core._pydantic_core.ValidationError: 1 validation error for SystemConfigDto
USER_USERNAME
  Field required [type=missing, input_value={'MODE': 'production', ...}, input_type=dict]

Grocy 4.7.0 omits USER_USERNAME when no session cookie is present. Since this integration only checks grocy_config.enabled_features to determine which platform entities to register, the USER_USERNAME field is unused downstream.
Testing Done
 * Verified against Grocy 4.7.0 running on Docker.
 * Verified against Home Assistant Core 2026.8.x.
 * Confirmed integration successfully completes setup and loads all expected entities (sensor, todo, etc.) without ValidationError.
 * Verified clean reload behavior without RecursionError.

